### PR TITLE
adds SSL config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 12 # uses version 12
+  - 14 # uses version 14
 services:
   - postgresql # starts up postgres
 addons:

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -6,9 +6,6 @@ let config;
 if (process.env.DATABASE_URL) {
   config = {
     logging: false,
-    operatorsAliases: false,
-    dialect: "postgres",
-    protocol: "postgres",
     ssl: true,
     dialectOptions: {
       ssl: {
@@ -19,8 +16,7 @@ if (process.env.DATABASE_URL) {
   }
 } else {
   config = {
-    logging: false,
-    operatorsAliases: false,
+    logging: false
   }
 }
 const client = new Sequelize(dbUrl, config)

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -2,7 +2,28 @@ const Sequelize = require('sequelize')
 const pkg = require('../../package.json')
 const dbName = process.env.NODE_ENV === 'test' ? `${pkg.name}-test` : pkg.name
 const dbUrl = process.env.DATABASE_URL || `postgres://localhost:5432/${dbName}`
-const client = new Sequelize(dbUrl, { logging: false, operatorsAliases: false })
+let config;
+if (process.env.DATABASE_URL) {
+  config = {
+    logging: false,
+    operatorsAliases: false,
+    dialect: "postgres",
+    protocol: "postgres",
+    ssl: true,
+    dialectOptions: {
+      ssl: {
+        require: true,
+        rejectUnauthorized: false,
+      },
+    },
+  }
+} else {
+  config = {
+    logging: false,
+    operatorsAliases: false,
+  }
+}
+const client = new Sequelize(dbUrl, config)
 
 module.exports = client
 


### PR DESCRIPTION
Due to a recent update on Heroku SSL is needed for postgres connections. This PR adds the necessary options in our Sequelize connection instance so that deployment works.